### PR TITLE
Updated readme and removed the a instance requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following code example does a few things to get you started a fast a possibl
 
 Before you copy/paste this code besure you've a api key to use. When developing and testing the api you probably don't  want
 to use the api key for production. Instead you want to use a developer api key. 
-A developer api key can be obtained by asking the support desk from Bunq itself (using the Bunq app). Once you've got that
+A developer api key can be obtained by asking the support desk from bunq itself (using the Bunq app). Once you've got that
 api key you can fill it in into the `$apiKey` variable.
  
 The function `registerInstallationAndDeviceServer()` is only supposed to be called only once. After the first call you can comment this rule away.
@@ -71,7 +71,7 @@ $keypair = Keypair::fromStrings(
 // Replace this with what you received from the app
 $apiKey = 'your-api-key';
 
-$debugMode = ture;
+$debugMode = true;
 $environment = new Sandbox($debugMode);
 $client = new Client($environment, $keypair);
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ Any feedback and testing is very much welcome though issues and/or pull requests
 
 ## Basic usage
 
+
+The following code example does a few things to get you started a fast a possible:
+
+1. Create an InstallationServer
+2. Create an DeviceServer
+3. Retrieve a session from de SessionServer to be able to use the api
+
+Before you copy/paste this code besure you've a api key to use. When developing and testing the api you probably don't  want
+to use the api key for production. Instead you want to use a developer api key. 
+A developer api key can be obtained by asking the support desk from Bunq itself (using the Bunq app). Once you've got that
+api key you can fill it in into the `$apiKey` variable.
+ 
+The function `registerInstallationAndDeviceServer()` is only supposed to be called only once. After the first call you can comment this rule away.
+
+
 ```php
 <?php
 
@@ -24,6 +39,28 @@ use Link0\Bunq\Service\InstallationService;
 
 require_once('vendor/autoload.php');
 
+/**
+ * @param $installationService
+ * @param $keypair
+ * @param $apiKey
+ * @return mixed
+ */
+function registerInstallationAndDeviceServer(InstallationService $installationService, $keypair, $apiKey)
+{
+    $installation = $installationService->createInstallation($keypair);
+
+    $installationToken = $installation[1];
+    $serverPublicKey = $installation[2];
+
+    // Cache the server public key somewhere
+    file_put_contents('server-public-key.txt', $serverPublicKey);
+
+    // Cache the installation token somehere
+    file_put_contents('installation-token.txt', $installationToken);
+
+    $installationService->createDeviceServer($installationToken, $apiKey, 'I pasted this from README.md');
+}
+
 // openssl genpkey -algorithm RSA -out private.pem -pkeyopt rsa_keygen_bits:2048
 // openssl rsa -pubout -in private.pem -out public.pem
 $keypair = Keypair::fromStrings(
@@ -32,29 +69,18 @@ $keypair = Keypair::fromStrings(
 );
 
 // Replace this with what you received from the app
-$apiKey = 'foobarbaz';
+$apiKey = 'your-api-key';
 
-$debugMode = true;
-$environment = new Sandbox($debugmode);
+$debugMode = ture;
+$environment = new Sandbox($debugMode);
 $client = new Client($environment, $keypair);
 
 $installationService = new InstallationService($client);
-$installation = $installationService->createInstallation($keypair);
 
-// Useful information
-print_r($installation);
+registerInstallationAndDeviceServer($installationService, $keypair, $apiKey);
 
-$installationId = $installation[0];
-$installationToken = $installation[1];
-$serverPublicKey = $installation[2];
+$installationToken = file_get_contents('installation-token.txt');
 
-// Cache the server public key somewhere
-file_put_contents('server-public-key.txt', $serverPublicKey);
-
-// Cache the installation token somehere
-file_put_contents('installation-token.txt', $installationToken);
-
-$deviceServerId = $installationService->createDeviceServer($installationToken, $apiKey, 'I pasted this from README.md');
 $sessionServer = $installationService->createSessionServer($installationToken, $apiKey);
 
 $sessionServerId = $sessionServer[0];
@@ -64,12 +90,12 @@ $user = $sessionServer[2];
 file_put_contents('session-token.txt', $sessionToken);
 
 // After this, you can use the client with all other services as followed
-
 $client = new Client(
     $environment,
     $keypair,
     new PublicKey(file_get_contents('server-public-key.txt')),
-    file_get_contents($sessionToken);
+    file_get_contents('session-token.txt')
 );
+
 
 ```

--- a/src/Service/InstallationService.php
+++ b/src/Service/InstallationService.php
@@ -45,7 +45,7 @@ final class InstallationService
     /**
      * @return Id $deviceServerId
      */
-    public function createDeviceServer(Token $token, string $apiKey, string $description): Id
+    public function createDeviceServer($token, string $apiKey, string $description): Id
     {
         $permittedIps = [];
 
@@ -61,7 +61,7 @@ final class InstallationService
     }
 
     /**
-     * @param Token $token
+     * @param $token
      * @param string $apiKey
      * @return array
      *
@@ -71,7 +71,7 @@ final class InstallationService
      *   'UserCompany' => ...
      * )
      */
-    public function createSessionServer(Token $token, string $apiKey): array
+    public function createSessionServer($token, string $apiKey): array
     {
         $body = ['secret' => $apiKey];
 


### PR DESCRIPTION
# What has been done
Updated the read me to more clear for new developers who are trying to adopt the package.

Be able to create a DeviceServer and SessionServer using only the string presentation of a token and not a specific instance. The reason why why I have changed this is because a token is not being stored as a Token instance. Its being stored as string. With this pr you can submit a string presentation of the token instead.
