### PR TITLE
Notification delivery method callback value difference in docs

### DIFF
--- a/src/Domain/NotificationFilter.php
+++ b/src/Domain/NotificationFilter.php
@@ -5,7 +5,7 @@ namespace Link0\Bunq\Domain;
 final class NotificationFilter
 {
     const DELIVERYMETHOD_PUSH = 'PUSH';
-    const DELIVERYMETHOD_CALLBACK = 'CALLBACK';
+    const DELIVERYMETHOD_CALLBACK = 'URL';
 
     const CATEGORY_BILLING = 'BILLING';
     const CATEGORY_CARD_TRANSACTION_FAILED = 'CARD_TRANSACTION_FAILED';


### PR DESCRIPTION
See: https://doc.bunq.com/api/1/page/callbacks

notification_delivery_method: choose between URL (sending an HTTP request to the provided URL) and PUSH (sending a push notification to user's phone). To receive callbacks, a notification has to be set for URL.